### PR TITLE
Fixed bug in PlasmaAnimation.ino

### DIFF
--- a/examples/PlasmaAnimation/PlasmaAnimation.ino
+++ b/examples/PlasmaAnimation/PlasmaAnimation.ino
@@ -9,7 +9,7 @@
 //OctoWS2811 Defn. Stuff
 #define COLS_LEDs 60  // all of the following params need to be adjusted for screen size
 #define ROWS_LEDs 16  // LED_LAYOUT assumed 0 if ROWS_LEDs > 8
-#define LEDS_PER_STRIP (COLS_LEDs * (ROWS_LEDs / 6))
+#define LEDS_PER_STRIP (COLS_LEDs * (ROWS_LEDs / 8))
 
 DMAMEM int displayMemory[LEDS_PER_STRIP*6];
 int drawingMemory[LEDS_PER_STRIP*6];


### PR DESCRIPTION
LEDS_PER_STRIP was artificially high using up extra space.  With 60 columns and 16 rows that means that you have 2 rows per strip and each strip would be 120 LEDs long. 60*16/8 = 120px per strip.  8x 120px strips = 960px total.

The size of the display and drawing buffers is accurately sized by a multiple of 6 (so I can see why this bug was introduced)
