### PR TITLE
fix include guard errors

### DIFF
--- a/OctoWS2811.h
+++ b/OctoWS2811.h
@@ -21,6 +21,8 @@
     THE SOFTWARE.
 */
 
+#ifndef OctoWS2811_h
+#define OctoWS2811_h
 
 #include <Arduino.h>
 #include "DMAChannel.h"
@@ -72,3 +74,4 @@ private:
 	static void isr(void);
 };
 
+#endif


### PR DESCRIPTION
Without this anyone wanting to include this into multiple header files gets an error.
