### PR TITLE
Allow to setup the library after instantiation

### DIFF
--- a/OctoWS2811.cpp
+++ b/OctoWS2811.cpp
@@ -37,8 +37,12 @@ static const uint8_t ones = 0xFF;
 static volatile uint8_t update_in_progress = 0;
 static uint32_t update_completed_at = 0;
 
+OctoWS2811::OctoWS2811()
+{
+    // Unusable
+}
 
-OctoWS2811::OctoWS2811(uint32_t numPerStrip, void *frameBuf, void *drawBuf, uint8_t config)
+void OctoWS2811::attach(uint32_t numPerStrip, void *frameBuf, void *drawBuf, uint8_t config)
 {
 	stripLen = numPerStrip;
 	frameBuffer = frameBuf;

--- a/OctoWS2811.h
+++ b/OctoWS2811.h
@@ -45,7 +45,8 @@
 
 class OctoWS2811 {
 public:
-	OctoWS2811(uint32_t numPerStrip, void *frameBuf, void *drawBuf, uint8_t config = WS2811_GRB);
+	OctoWS2811();
+	void attach(uint32_t numPerStrip, void *frameBuf, void *drawBuf, uint8_t config = WS2811_GRB);
 	void begin(void);
 
 	void setPixel(uint32_t num, int color);


### PR DESCRIPTION
I'm not sure you are interested in merging such a patch (not backward compatible), but it is required to be able to dynamically initialize the amount of LEDs on the strips in the setup function.

That's what we do here: 
- https://github.com/syn2cat/syndilights/blob/master/v2/backend/arduino/VideoDisplayTeensy31/VideoDisplayTeensy31.ino
