### PR TITLE
Adding empty constructor

### DIFF
--- a/OctoWS2811.cpp
+++ b/OctoWS2811.cpp
@@ -47,6 +47,10 @@ OctoWS2811::OctoWS2811(uint32_t numPerStrip, void *frameBuf, void *drawBuf, uint
 	params = config;
 }
 
+OctoWS2811::OctoWS2811()
+{
+}
+
 // Waveform timing: these set the high time for a 0 and 1 bit, as a fraction of
 // the total 800 kHz or 400 kHz clock cycle.  The scale is 0 to 255.  The Worldsemi
 // datasheet seems T1H should be 600 ns of a 1250 ns cycle, or 48%.  That may

--- a/OctoWS2811.h
+++ b/OctoWS2811.h
@@ -53,6 +53,7 @@
 class OctoWS2811 {
 public:
 	OctoWS2811(uint32_t numPerStrip, void *frameBuf, void *drawBuf, uint8_t config = WS2811_GRB);
+	OctoWS2811();
 	void begin(void);
 	void begin(uint32_t numPerStrip, void *frameBuf, void *drawBuf, uint8_t config = WS2811_GRB);
 


### PR DESCRIPTION
Adding an empty constructor to be able to construct an empty version of OctoWS2811 to be filled later from another class.

example:

```
OctoWS2811 leds();
leds = OctoWS2811(LedsPerStrip, displayMemory, drawingMemory, config);
leds.begin();
```


note:
not a native c++ programmer but i did not find any other way to make a construction like this unless i added this constructor myself. 
Would like to have it added to the library so we don't have to use our own version of OctoWS2811.
Change did not seem to do any harm to the rest of the code.

Any comments/advice welcome.