### PR TITLE
fix busy() for Teensy4

### DIFF
--- a/OctoWS2811_imxrt.cpp
+++ b/OctoWS2811_imxrt.cpp
@@ -363,7 +363,7 @@ void OctoWS2811::isr(void)
 
 int OctoWS2811::busy(void)
 {
-	if (!dma3.complete()) ; // DMA still running
+	if (!dma3.complete()) return 1; // DMA still running
 	if (micros() - update_begin_micros < numbytes * 10 + 300) return 1; // WS2812 reset
 	return 0;
 }


### PR DESCRIPTION
Looks like there is a missing return statement.
This PR fixes that.
